### PR TITLE
Rearrange level exercises towards a particular progression

### DIFF
--- a/COFFEE_LEVELS.md
+++ b/COFFEE_LEVELS.md
@@ -7,13 +7,4 @@
 5. Visibly oscillating
 6. I CAN SEE THROUGH TIME
 7. TIME SEES THROUGH YOU
-
-# Coffee State Machine Testing Levels
-
-1. First tests
-   - a. Set up hedgehog, inc. tasty-hedgehog
-   - b. No-arg commands to switch drink
-2. Collect drink-switch commands into one command
-3. Add/remove mug
-   - a. Note breakage
-   - b. `Require` callback - need happy/sad commands to test things properly
+8. Cthulu: "Is it really you? After all this time!"

--- a/Lens_Cheatsheet.md
+++ b/Lens_Cheatsheet.md
@@ -2,7 +2,8 @@
 
 We will be using lenses in the content of the course, and we encourage you to
 use them as well. Primarily we will be applying lenses in their simplest form,
-that is as generalised "getters" and "setters".
+that is as generalised "getters" and "setters". We may also use prisms, which
+can be thought of as constructors and first-class pattern matches. 
 
 This document will contain examples and explanations to provide an easily
 digestible to the lenses that are used in this course:
@@ -47,6 +48,7 @@ let foo = Foo "Fred" 33
 ### As 'getters'
 
 | # | Function/Operator   | Example                                  |
+|---|---------------------|------------------------------------------|
 | 1 | `view`              | `view fooFieldA foo           == "Fred"` |
 | 2 | `^.` (infix `view`) | `foo ^. fooFieldA             == "Fred"` |
 | 3 | `to`                | `foo ^. fooFieldA . to length == 4`      |
@@ -54,12 +56,14 @@ let foo = Foo "Fred" 33
 #### Non-lens equivalents:
 
 | #   | Example                             |
+|-----|-------------------------------------|
 | 1,2 | `_fooFieldA foo          == "Fred"` |
 | 3   | `length (_fooFieldA foo) == 4`      |
 
 ### As 'setters'
 
 | # | Function/Operator  | Example                                               |
+|---|--------------------|-------------------------------------------------------|
 | 1 | `set`              | `set fooFieldA "Sally" foo         == Foo "Sally" 33` |
 | 2 | `.~` (infix `set`) | `foo & fooFieldA .~ "Sally"        == Foo "Sally" 33` |
 | 3 | `+~`               | `foo & fooFieldB +~ 3              == Foo "Fred" 36`  |
@@ -68,6 +72,7 @@ let foo = Foo "Fred" 33
 #### Non-lens equivalents:
 
 |   # | Example                                                                |
+|-----|------------------------------------------------------------------------|
 | 1,2 | `foo { _fooFieldA = "Sally" }                       == Foo "Sally" 33` |
 |   3 | `foo { _fooFieldB = _fooFieldB foo + 3 }            == Foo "Fred" 36`  |
 |   4 | `foo { _fooFieldB = fmap toUpper (_fooFieldA foo) } == Foo "FRED" 33`  |

--- a/Lens_Cheatsheet.md
+++ b/Lens_Cheatsheet.md
@@ -1,0 +1,62 @@
+# Lens - A Cheatsheet
+
+We will be using lenses in the content of the course, and we encourage you to
+use them as well. Primarily we will be applying lenses in their simplest form,
+that is as generalised "getters" and "setters".
+
+This document will contain examples and explanations to provide an easily
+digestible to the lenses that are used in this course:
+
+Given the following Haskell record:
+
+```haskell
+data Foo = Foo
+  { _fooFieldA :: Text
+  , _fooFieldB :: Int
+  }
+```
+
+### Generating the lenses
+
+We will use Template Haskell to write the code for us. We only need to enable
+the `TemplateHaskell` language extension and add the following line below our
+type:
+
+```haskell
+$(makeLenses ''Foo)
+```
+
+This will generate the following lenses for us:
+
+```haskell
+fooFieldA :: Lens' Foo Text
+fooFieldB :: Lens' Foo Int
+```
+
+Note that the functions are named exactly as our field names on `Foo`, save for
+removing the initial `_` prefix. This is merely a convention from the `lens`
+package. The name transformation may be changed by providing additional options
+to the template haskell functions.
+
+Using the lenses we generated earlier and given the following value:
+
+```haskell
+let foo = Foo "Fred" 33
+```
+
+### As 'getters'
+
+| Function/Operator | Example                             |
+| `view`            | `view fooFieldA foo == "Fred"`      |
+| `^.`              | `foo ^. fooFieldA == "Fred"`        |
+| `to`              | `foo ^. fooFieldA . to length == 4` |
+
+### As 'setters'
+
+| Function/Operator | Example                                              |
+| `set`             | `set fooFieldA "Sally" foo == Foo "Sally" 33`        |
+| `.~`              | `foo & fooFieldA .~ "Sally" == Foo "Sally" 33`       |
+| `+~`              | `foo & fooFieldB +~ 3 == Foo "Fred" 36`              |
+| `over`            | `over fooFieldA (fmap toUpper) foo == Foo "FRED" 33` |
+|                   |                                                      |
+

--- a/Lens_Cheatsheet.md
+++ b/Lens_Cheatsheet.md
@@ -6,8 +6,8 @@ form, as generalised "getters" and "setters". We may also use prisms,
 which can be thought of as a combination of a constructor and
 first-class pattern.
 
-This document will contain examples and explanations to provide an
-easily digestible to the lenses that are used in this course:
+This document contains examples and explanations to provide an easily digestible
+introduction to the lenses that are used in this course:
 
 ## Generating Lenses
 

--- a/Lens_Cheatsheet.md
+++ b/Lens_Cheatsheet.md
@@ -1,8 +1,10 @@
 # Lens - A Cheatsheet
 
-We will be using lenses in the content of the course, and we encourage
-you to use them as well. A `Lens' s a` accesses exactly one `a` within
-some structure `s`.
+We will be using lenses in the content of the course, and we encourage you to
+use them as well. A `Lens` is a generalised combination of a "getter" and a
+"setter", the type signature for a `Lens` may be read as:
+
+A `Lens' s a` accesses exactly one `a` within some structure `s`.
 
 This document contains examples and explanations to provide an easily
 digestible introduction to the lenses that are used in this course:

--- a/Lens_Cheatsheet.md
+++ b/Lens_Cheatsheet.md
@@ -1,30 +1,26 @@
 # Lens - A Cheatsheet
 
-We will be using lenses in the content of the course, and we encourage you to
-use them as well. Primarily we will be applying lenses in their simplest form,
-that is as generalised "getters" and "setters". We may also use prisms, which
-can be thought of as constructors and first-class pattern matches. 
+We will be using lenses in the content of the course, and we encourage
+you to use them as well. We'll mostly use lenses in their simplest
+form, as generalised "getters" and "setters". We may also use prisms,
+which can be thought of as a combination of a constructor and
+first-class pattern.
 
-This document will contain examples and explanations to provide an easily
-digestible to the lenses that are used in this course:
+This document will contain examples and explanations to provide an
+easily digestible to the lenses that are used in this course:
 
-Given the following Haskell record:
+## Generating Lenses
+
+We can generate lenses for the following Haskell record using `{-#
+LANGUAGE TemplateHaskell #-}` and one line of code:
 
 ```haskell
 data Foo = Foo
   { _fooFieldA :: Text
   , _fooFieldB :: Int
   }
-```
 
-### Generating the lenses
-
-We will use Template Haskell to write the code for us. We only need to enable
-the `TemplateHaskell` language extension and add the following line below our
-type:
-
-```haskell
-$(makeLenses ''Foo)
+$(makeLenses ''Foo) -- Make me some lenses!
 ```
 
 This will generate the following lenses for us:
@@ -34,10 +30,13 @@ fooFieldA :: Lens' Foo Text
 fooFieldB :: Lens' Foo Int
 ```
 
-Note that the functions are named exactly as our field names on `Foo`, save for
-removing the initial `_` prefix. This is merely a convention from the `lens`
-package. The name transformation may be changed by providing additional options
-to the template haskell functions.
+These lenses pick out a `Text`/`Int` from a `Foo`, or can be used to
+update a `Text`/`Int` inside a `Foo`. Note that the lenses are named
+after field names on `Foo`, minus the initial `_` prefix. This
+convention is expected by `makeLenses`. It is possible to configure
+it, but few do.
+
+## Using Lenses
 
 Using the lenses we generated earlier and given the following value:
 
@@ -47,11 +46,11 @@ let foo = Foo "Fred" 33
 
 ### As 'getters'
 
-| # | Function/Operator   | Example                                  |
-|---|---------------------|------------------------------------------|
-| 1 | `view`              | `view fooFieldA foo           == "Fred"` |
-| 2 | `^.` (infix `view`) | `foo ^. fooFieldA             == "Fred"` |
-| 3 | `to`                | `foo ^. fooFieldA . to length == 4`      |
+| # | Function/Operator                            | Example                                  |
+|---|----------------------------------------------|------------------------------------------|
+| 1 | `view`                                       | `view fooFieldA foo           == "Fred"` |
+| 2 | `^.` (infix `view`)                          | `foo ^. fooFieldA             == "Fred"` |
+| 3 | `to` (turn a nomal function into a "getter") | `foo ^. fooFieldA . to length == 4`      |
 
 #### Non-lens equivalents:
 
@@ -76,3 +75,13 @@ let foo = Foo "Fred" 33
 | 1,2 | `foo { _fooFieldA = "Sally" }                       == Foo "Sally" 33` |
 |   3 | `foo { _fooFieldB = _fooFieldB foo + 3 }            == Foo "Fred" 36`  |
 |   4 | `foo { _fooFieldB = fmap toUpper (_fooFieldA foo) } == Foo "FRED" 33`  |
+
+## Prisms
+
+TODO
+
+## Composing
+
+`Lens`es (and other optics like `Prism`s) compose with each other using `(.)`.
+
+TODO

--- a/Lens_Cheatsheet.md
+++ b/Lens_Cheatsheet.md
@@ -46,17 +46,28 @@ let foo = Foo "Fred" 33
 
 ### As 'getters'
 
-| Function/Operator | Example                             |
-| `view`            | `view fooFieldA foo == "Fred"`      |
-| `^.`              | `foo ^. fooFieldA == "Fred"`        |
-| `to`              | `foo ^. fooFieldA . to length == 4` |
+| # | Function/Operator   | Example                                  |
+| 1 | `view`              | `view fooFieldA foo           == "Fred"` |
+| 2 | `^.` (infix `view`) | `foo ^. fooFieldA             == "Fred"` |
+| 3 | `to`                | `foo ^. fooFieldA . to length == 4`      |
+
+#### Non-lens equivalents:
+
+| #   | Example                             |
+| 1,2 | `_fooFieldA foo          == "Fred"` |
+| 3   | `length (_fooFieldA foo) == 4`      |
 
 ### As 'setters'
 
-| Function/Operator | Example                                              |
-| `set`             | `set fooFieldA "Sally" foo == Foo "Sally" 33`        |
-| `.~`              | `foo & fooFieldA .~ "Sally" == Foo "Sally" 33`       |
-| `+~`              | `foo & fooFieldB +~ 3 == Foo "Fred" 36`              |
-| `over`            | `over fooFieldA (fmap toUpper) foo == Foo "FRED" 33` |
-|                   |                                                      |
+| # | Function/Operator  | Example                                               |
+| 1 | `set`              | `set fooFieldA "Sally" foo         == Foo "Sally" 33` |
+| 2 | `.~` (infix `set`) | `foo & fooFieldA .~ "Sally"        == Foo "Sally" 33` |
+| 3 | `+~`               | `foo & fooFieldB +~ 3              == Foo "Fred" 36`  |
+| 4 | `over`             | `over fooFieldA (fmap toUpper) foo == Foo "FRED" 33`  |
 
+#### Non-lens equivalents:
+
+|   # | Example                                                                |
+| 1,2 | `foo { _fooFieldA = "Sally" }                       == Foo "Sally" 33` |
+|   3 | `foo { _fooFieldB = _fooFieldB foo + 3 }            == Foo "Fred" 36`  |
+|   4 | `foo { _fooFieldB = fmap toUpper (_fooFieldA foo) } == Foo "FRED" 33`  |

--- a/Lens_Cheatsheet.md
+++ b/Lens_Cheatsheet.md
@@ -1,13 +1,11 @@
 # Lens - A Cheatsheet
 
 We will be using lenses in the content of the course, and we encourage
-you to use them as well. We'll mostly use lenses in their simplest
-form, as generalised "getters" and "setters". We may also use prisms,
-which can be thought of as a combination of a constructor and
-first-class pattern.
+you to use them as well. A `Lens' s a` accesses exactly one `a` within
+some structure `s`.
 
-This document will contain examples and explanations to provide an
-easily digestible to the lenses that are used in this course:
+This document will contain enough examples to provide a cheat-sheet
+for the lens/prism-using code in this course:
 
 ## Generating Lenses
 
@@ -87,6 +85,7 @@ Prisms are generated using the `makePrisms` template haskell function:
 
 ```haskell
 data Bar = Baz Foo | Quux Bool
+
 $(makePrisms ''Bar)
 ```
 

--- a/Lens_Cheatsheet.md
+++ b/Lens_Cheatsheet.md
@@ -120,6 +120,12 @@ let
 
 # Composing
 
-`Lens`es (and other optics like `Prism`s) compose with each other using `(.)`.
+`Lens`es (and other optics like `Prism`s) compose with each other
+using `(.)` giving an effect that looks a lot like dot-notation in
+other languages. This composition is where the payoffs really start,
+as it's possible to reach deep into data structures without doing many
+levels of `case`-expressions:
 
-TODO
+```haskell
+baz ^? _Baz . fooFieldA == Just "Fred"
+```

--- a/Lens_Cheatsheet.md
+++ b/Lens_Cheatsheet.md
@@ -76,11 +76,49 @@ let foo = Foo "Fred" 33
 |   3 | `foo { _fooFieldB = _fooFieldB foo + 3 }            == Foo "Fred" 36`  |
 |   4 | `foo { _fooFieldB = fmap toUpper (_fooFieldA foo) } == Foo "FRED" 33`  |
 
-## Prisms
+# Prisms
 
-TODO
+Prisms are like lenses for sum types. Instead of focusing on exactly
+one value, a `Prism' s a` will extract at most one `a` from `s`.
 
-## Composing
+## Generating Prisms
+
+Prisms are generated using the `makePrisms` template haskell function:
+
+```haskell
+data Bar = Baz Foo | Quux Bool
+$(makePrisms ''Bar)
+```
+
+This will generate prisms `_Baz :: Prism' Bar Foo` and `_Quux ::
+Prism' Bar Bool`.
+
+### Using Prisms
+
+Given the two prisms above, and the following values:
+
+```haskell
+let
+  baz = Baz (Foo "Fred" 33)
+  quux = Quux True
+```
+
+#### Previewing
+
+| # | Function/Operator        | Example                                    |
+|---|--------------------------|--------------------------------------------|
+| 1 | `preview`                | `preview _Baz baz == Just (Foo "Fred" 33)` |
+| 2 | `preview`                | `preview _Baz quux == Nothing`             |
+| 3 | `(^?)` (infix `preview`) | `quux ^? _Quux == Just True`               |
+| 4 | `(^?)` (infix `preview`) | `baz ^? _Quux == Nothing`                  |
+
+#### Reviewing
+
+| # | Function/Operator      | Example                     |
+| 1 | `review`               | `review _Quux True == quux` |
+| 2 | `(#)` (infix `review`) | `_Quux # True == quux`      |
+
+# Composing
 
 `Lens`es (and other optics like `Prism`s) compose with each other using `(.)`.
 

--- a/Other_Languages.md
+++ b/Other_Languages.md
@@ -1,0 +1,14 @@
+## Other languages
+
+Haskell isn't unique in the ability to apply these powerful testing techniques
+to stateful systems.
+
+Here are some property-based testing libraries that have varying levels of
+support for testing stateful systems.
+
+* Scala: [ScalaCheck](https://www.scalacheck.org/):
+  * [Docs](https://github.com/rickynils/scalacheck/blob/master/doc/UserGuide.md#stateful-testing)
+  * [Presentation](http://parleys.com/play/53a7d2d0e4b0543940d9e566)
+
+* Python: [Hypothesis](https://hypothesis.works/) 
+  * [Post](https://hypothesis.works/articles/rule-based-stateful-testing/)

--- a/README.md
+++ b/README.md
@@ -49,24 +49,20 @@ a course about testing, each level is a separate `test-suite` in the
 
 ## Course Structure
 
-- Setting Up
+- [0] Setting Up
   - Preparing the project
   - Setting [hedgehog](https://hackage.haskell.org/package/hedgehog)
   - Structuring your tests using [tasty-hedgehog](https://hackage.haskell.org/package/tasty-hedgehog)
 
-- First tests
+- [1] First tests
   - Terminology and `Command` structure
   - Some simple commands
   - Discussion of test feedback and interpreting errors
 
-- More Commands
-  - Commands with arguments
-  - We broke it! Oh no.
+- [2] `Require` & Pre-conditions
 
-- Flexing the model
-  - `Require`
-  - Better coverage with positive and negative tests.
+- [3] More Commands
+  
+- [4] Positive & Negative Testing
 
-- Pre-conditions
-
-- Phases and growing models
+- [5] Phases and growing models

--- a/default.nix
+++ b/default.nix
@@ -20,9 +20,7 @@ let
   drv = pkgs.haskellPackages.callPackage ./state-machine-testing-course.nix {};
 
   drvWithTools = pkgs.haskell.lib.addBuildTools drv
-    [ # Include our beloved and standard text editor
-      pkgs.ed
-      # A development tool for great justice
+    [ # A development tool for great justice
       (pkgs.haskell.lib.justStaticExecutables pkgs.haskellPackages.ghcid)
       (pkgs.haskell.lib.justStaticExecutables pkgs.haskellPackages.cabal-install)
     ];

--- a/level02/CoffeeMachineTests.hs
+++ b/level02/CoffeeMachineTests.hs
@@ -7,6 +7,7 @@ import qualified CoffeeMachine as C
 import           Control.Lens (view)
 import           Control.Monad.IO.Class (MonadIO)
 import           Data.Kind (Type)
+import           Data.Maybe (isJust)
 import           Hedgehog
 import qualified Hedgehog.Gen as Gen
 import qualified Hedgehog.Range as Range
@@ -14,11 +15,20 @@ import           Test.Tasty (TestTree)
 import           Test.Tasty.Hedgehog (testProperty)
 
 data DrinkType = Coffee | HotChocolate | Tea
-newtype Model (v :: Type -> Type) = Model DrinkType
 
+data Model (v :: Type -> Type) = Model DrinkType Bool
+
+data AddMug (v :: Type -> Type) = AddMug deriving Show
+data TakeMug (v :: Type -> Type) = TakeMug deriving Show
 data SetDrinkCoffee (v :: Type -> Type) = SetDrinkCoffee deriving Show
 data SetDrinkHotChocolate (v :: Type -> Type) = SetDrinkHotChocolate deriving Show
 data SetDrinkTea (v :: Type -> Type) = SetDrinkTea deriving Show
+
+instance HTraversable AddMug where
+  htraverse _ _ = pure AddMug
+
+instance HTraversable TakeMug where
+  htraverse _ _ = pure TakeMug
 
 instance HTraversable SetDrinkCoffee where
   htraverse _ _ = pure SetDrinkCoffee
@@ -34,7 +44,7 @@ cSetDrinkCoffee
   => C.Machine
   -> Command g m Model
 cSetDrinkCoffee mach = Command gen exec
-  [ Update $ \_ _ _ -> Model Coffee
+  [ Update $ \(Model _ hasMug) _ _ -> Model Coffee hasMug
   , Ensure $ \_ _ _ drink -> case drink of
       C.Coffee{} -> success
       _ -> failure
@@ -53,7 +63,7 @@ cSetDrinkHotChocolate
   => C.Machine
   -> Command g m Model
 cSetDrinkHotChocolate mach = Command gen exec
-  [ Update $ \_ _ _ -> Model HotChocolate
+  [ Update $ \(Model _ hasMug) _ _ -> Model HotChocolate hasMug
   , Ensure $ \_ _ _ drink -> case drink of
       C.HotChocolate -> success
       _ -> failure
@@ -72,7 +82,7 @@ cSetDrinkTea
   => C.Machine
   -> Command g m Model
 cSetDrinkTea mach = Command gen exec
-  [ Update $ \_ _ _ -> Model Tea
+  [ Update $ \(Model _ hasMug) _ _ -> Model Tea hasMug
   , Ensure $ \_ _ _ drink -> case drink of
       C.Tea{} -> success
       _ -> failure
@@ -86,15 +96,52 @@ cSetDrinkTea mach = Command gen exec
       C.tea mach
       view C.drinkSetting <$> C.peek mach
 
+cTakeMug
+  :: forall g m. (MonadGen g, MonadTest m, MonadIO m)
+  => C.Machine
+  -> Command g m Model
+cTakeMug mach = Command gen exec
+  [ Require $ \(Model _ hasMug) _ -> hasMug
+  , Update $ \(Model dt _) _ _ -> Model dt False
+  ]
+  where
+    gen :: MonadGen g => Model Symbolic -> Maybe (g (TakeMug Symbolic))
+    gen (Model _ hasMug) | hasMug    = (pure . pure) TakeMug
+                         | otherwise = Nothing
+
+    exec :: TakeMug Concrete -> m C.Mug
+    exec _ = evalIO (C.takeMug mach) >>= evalEither
+
+cAddMug
+  :: forall g m. (MonadGen g, MonadTest m, MonadIO m)
+  => C.Machine
+  -> Command g m Model
+cAddMug mach = Command gen exec
+  [ Require $ \(Model _ hasMug) _ -> not hasMug
+  , Update $ \(Model dt _) _ _ -> Model dt True
+  , Ensure $ \_ _ _ -> assert . isJust
+  ]
+  where
+    gen :: MonadGen g => Model Symbolic -> Maybe (g (AddMug Symbolic))
+    gen (Model _ hasMug) | not hasMug = (pure . pure) AddMug
+                         | otherwise  = Nothing
+
+    exec :: AddMug Concrete -> m (Maybe C.Mug)
+    exec _ = do
+      evalIO (C.addMug mach) >>= evalEither
+      evalIO $ view C.mug <$> C.peek mach
+
 stateMachineTests :: TestTree
 stateMachineTests = testProperty "State Machine Tests" . property $ do
   mach <- C.newMachine
 
-  let initialModel = Model HotChocolate
+  let initialModel = Model HotChocolate False
       commands = ($ mach) <$>
         [ cSetDrinkCoffee
         , cSetDrinkHotChocolate
         , cSetDrinkTea
+        , cTakeMug
+        , cAddMug
         ]
 
   actions <- forAll $ Gen.sequential (Range.linear 1 100) initialModel commands

--- a/level02/README.md
+++ b/level02/README.md
@@ -1,32 +1,36 @@
 # Level 02 - Pre-conditions & Commands with arguments
 
-So far they have all separate parts of our model. There are no dependencies so
-Hedgehog is free to generate and shrink as it chooses, any sequence of commands
-is as valid as any other.
+We've built some simple `Command`s to ensure we can keep selecting different
+drink types and our machine doesn't explode. Yay. Note that because of how we've
+built these `Command`s, any sequence of `Command`s is as valid as any other.
+Which is okay when particular actions may be run regardless of what state the
+system is in.
 
-But we need a way to ensure that some commands will only run when it makes sense
-to do so. Otherwise the randomised aspect of our tests is no longer beneficial
-and we're left with a non-deterministic test suite. All because some commands
-have been included in an absurd order.
+What about when a `Command` does not make sense to run unless the system has
+reached a particular state? If we do not manage this, the randomised aspect of
+our tests is no longer beneficial. We're left with a non-deterministic test
+suite because some `Command`s _might_ be included in an absurd order.
 
-We will solve this by using the `Require` callback to inform hedgehog that a
-given command is to be included. We will use the `takeMug` function as an
-example.
+We solve this by using the `Require` callback to inform Hedgehog that this
+`Command` is valid in the current sequence. We will use the `takeMug` function
+as an example.
 
 Including a `Command` for this function without the appropriate pre-condition
-would result in our tests passing only when this command was included after a
+would result in our tests passing only when this `Command` was included after a
 call to `addMug`, with no other `takeMug` being called in between.
 
-However if we expanded our model to track the status the mug. Then we could
-prevent the `takeMug` command from being included as a valid command unless our
-criteria had been satisified. Later on we'll go into more detail about how
-adding these smaller "state transitions" to your model can make things easier.
+However if we expanded our model with a value to track the status of the mug.
+Then we can prevent the `takeMug` `Command` from being included unless our
+criteria have been satisified.
+
+Later on we'll go into more detail about how adding these smaller "state
+transitions" to your model can make things easier.
 
 The goals for this level are to implement the following commands:
 
 ### Add Mug
 
-We add a function using the oddly named function:
+We add a mug using the oddly named function:
 
 ```haskell
 addMug :: MonadIO m => Machine -> m (Either MachineError ())
@@ -34,7 +38,7 @@ addMug :: MonadIO m => Machine -> m (Either MachineError ())
 
 ### Take Mug
 
-Similarly, we may remove a mug by calling the following function:
+Similarly, we may remove a mug with the function:
 
 ```haskell
 takeMug :: MonadIO m => Machine -> m (Either MachineError Mug)
@@ -42,13 +46,13 @@ takeMug :: MonadIO m => Machine -> m (Either MachineError Mug)
 
 ### Collapse the `DrinkType` commands to one
 
-We're able to express the individual commands for setting the different types of
-drink in a more condensed manner. Collapse the following three commands:
+We're able to express the individual `Command`s for setting the different types
+of drink in a more condensed manner. Collapse the following three `Command`s:
 
 * `cSetDrinkHotChocolate`
 * `cSetDrinkCoffee`
 * `cSetDrinkTea`
 
-To one single command:
+To a single `Command`:
 
 * `cSetDrinkType`

--- a/level02/README.md
+++ b/level02/README.md
@@ -1,27 +1,26 @@
-# Level 02 - Require & Pre-conditions
+# Level 02 - Pre-conditions & Commands with arguments
 
-We're starting to build up an nice list of commands. So far they have all
-separate parts of our model. There are no dependencies so Hedgehog is free to
-generate and shrink as it chooses, any sequence of commands is as valid as any
-other.
+So far they have all separate parts of our model. There are no dependencies so
+Hedgehog is free to generate and shrink as it chooses, any sequence of commands
+is as valid as any other.
 
-But we need a way to ensure that our commands will only run when it makes sense
-to do so. Otherwise we will have commands that execute and fail our tests when
-those commands should never have been included to begin with.
+But we need a way to ensure that some commands will only run when it makes sense
+to do so. Otherwise the randomised aspect of our tests is no longer beneficial
+and we're left with a non-deterministic test suite. All because some commands
+have been included in an absurd order.
 
-We will use the `takeMug` function as an example. If we were to include a
-`Command` for this function without an appropriate `Require`, our tests would
-pass randomly, only when this command happened to be included in the right
-order.
+Let's use the `takeMug` function as an example.
+
+If we were to include a `Command` for this function without an appropriate
+pre-condition to check that we had, at somepoint, added a mug. Our tests would
+pass only when this command happened to be included after a call to `addMug`,
+with no other `takeMug` being called in between.
 
 However if we expanded our model to track whether we had added a mug. Then we
 could prevent the `takeMug` command from being a valid command unless our
-criteria had been satisified.
+criteria had been satisified. Later on we'll go into more detail about how
+adding these smaller "state transitions" to your model can make things easier.
 
-The type of drink we have selected is another example of this. If we wanted to
-check that the buttons to add milk or sugar were working correctly, then we need
-to make sure we have the correct type of drink selected.
- 
 The goals for this level are to implement the following commands:
 
 * Add Mug

--- a/level02/README.md
+++ b/level02/README.md
@@ -6,7 +6,7 @@ without our machine exploding. Yay. Note that because of how we've built these
 only when we have actions that can always run, regardless of the current state
 of the system.
 
-What about when we have `Command`s that do not make sense to, run unless the
+What about when we have `Command`s that do not make sense to run unless the
 system has reached a particular state? If we do not manage this, we are re left
 with a non-deterministic test suite because some `Command`s _might_ be generated
 in an absurd order.

--- a/level02/README.md
+++ b/level02/README.md
@@ -1,0 +1,29 @@
+# Level 02 - Require & Pre-conditions
+
+We're starting to build up an nice list of commands. So far they have all
+separate parts of our model. There are no dependencies so Hedgehog is free to
+generate and shrink as it chooses, any sequence of commands is as valid as any
+other.
+
+But we need a way to ensure that our commands will only run when it makes sense
+to do so. Otherwise we will have commands that execute and fail our tests when
+those commands should never have been included to begin with.
+
+We will use the `takeMug` function as an example. If we were to include a
+`Command` for this function without an appropriate `Require`, our tests would
+pass randomly, only when this command happened to be included in the right
+order.
+
+However if we expanded our model to track whether we had added a mug. Then we
+could prevent the `takeMug` command from being a valid command unless our
+criteria had been satisified.
+
+The type of drink we have selected is another example of this. If we wanted to
+check that the buttons to add milk or sugar were working correctly, then we need
+to make sure we have the correct type of drink selected.
+ 
+The goals for this level are to implement the following commands:
+
+* Add Mug
+* Take Mug
+* Reimplement the `DrinkType` commands from Level01 in a single command

--- a/level02/README.md
+++ b/level02/README.md
@@ -9,20 +9,46 @@ to do so. Otherwise the randomised aspect of our tests is no longer beneficial
 and we're left with a non-deterministic test suite. All because some commands
 have been included in an absurd order.
 
-Let's use the `takeMug` function as an example.
+We will solve this by using the `Require` callback to inform hedgehog that a
+given command is to be included. We will use the `takeMug` function as an
+example.
 
-If we were to include a `Command` for this function without an appropriate
-pre-condition to check that we had, at somepoint, added a mug. Our tests would
-pass only when this command happened to be included after a call to `addMug`,
-with no other `takeMug` being called in between.
+Including a `Command` for this function without the appropriate pre-condition
+would result in our tests passing only when this command was included after a
+call to `addMug`, with no other `takeMug` being called in between.
 
-However if we expanded our model to track whether we had added a mug. Then we
-could prevent the `takeMug` command from being a valid command unless our
+However if we expanded our model to track the status the mug. Then we could
+prevent the `takeMug` command from being included as a valid command unless our
 criteria had been satisified. Later on we'll go into more detail about how
 adding these smaller "state transitions" to your model can make things easier.
 
 The goals for this level are to implement the following commands:
 
-* Add Mug
-* Take Mug
-* Reimplement the `DrinkType` commands from Level01 in a single command
+### Add Mug
+
+We add a function using the oddly named function:
+
+```haskell
+addMug :: MonadIO m => Machine -> m (Either MachineError ())
+```
+
+### Take Mug
+
+Similarly, we may remove a mug by calling the following function:
+
+```haskell
+takeMug :: MonadIO m => Machine -> m (Either MachineError Mug)
+```
+
+### Collapse the `DrinkType` commands to one
+
+We're able to express the individual commands for setting the different types of
+drink in a more condensed manner. Collapse the following three commands:
+
+* `cSetDrinkHotChocolate`
+* `cSetDrinkCoffee`
+* `cSetDrinkTea`
+
+To one single command:
+
+* `cSetDrinkType`

--- a/level02/README.md
+++ b/level02/README.md
@@ -1,36 +1,39 @@
 # Level 02 - Pre-conditions & Commands with arguments
 
-We've built some simple `Command`s to ensure we can keep selecting different
-drink types and our machine doesn't explode. Yay. Note that because of how we've
-built these `Command`s, any sequence of `Command`s is as valid as any other.
-Which is okay when particular actions may be run regardless of what state the
-system is in.
+We've built some simple `Command`s to ensure we can select different drink types
+without our machine exploding. Yay. Note that because of how we've built these
+`Command`s, any sequence of `Command`s is as valid as any other. Which is okay
+only when we have actions that can always run, regardless of the current state
+of the system.
 
-What about when a `Command` does not make sense to run unless the system has
-reached a particular state? If we do not manage this, the randomised aspect of
-our tests is no longer beneficial. We're left with a non-deterministic test
-suite because some `Command`s _might_ be included in an absurd order.
+What about when we have `Command`s that do not make sense to, run unless the
+system has reached a particular state? If we do not manage this, we are re left
+with a non-deterministic test suite because some `Command`s _might_ be generated
+in an absurd order.
 
-We solve this by using the `Require` callback to inform Hedgehog that this
-`Command` is valid in the current sequence. We will use the `takeMug` function
-as an example.
+We solve this by using the `Require` callback, which allows Hedgehog to test
+that a `Command` is valid in the current sequence. We will use the `takeMug`
+function as an example.
 
-Including a `Command` for this function without the appropriate pre-condition
-would result in our tests passing only when this `Command` was included after a
-call to `addMug`, with no other `takeMug` being called in between.
+Including a `Command` for this function without a `Require` callback would
+result in our tests passing only when this `Command` was included after a call
+to `addMug`, with no other `takeMug` being called in between.
 
-However if we expanded our model with a value to track the status of the mug.
-Then we can prevent the `takeMug` `Command` from being included unless our
-criteria have been satisified.
+By expanding our model with a value to track the status of the mug, we can
+prevent the `takeMug` `Command` from being included unless our preconditions
+have been satisified.
 
-Later on we'll go into more detail about how adding these smaller "state
-transitions" to your model can make things easier.
+Doesn't this mean that our tests are only testing the "happy path"? Yes. We will
+address this in a future level. Later on we'll also go into more detail about
+how adding these smaller "state transitions" to your model can make things
+easier.
 
-The goals for this level are to implement the following commands:
+The goals for this level are to implement `Commands` for the following
+functions, including sensible `Require` callbacks:
 
 ### Add Mug
 
-We add a mug using the oddly named function:
+We add a mug using the `addMug` function:
 
 ```haskell
 addMug :: MonadIO m => Machine -> m (Either MachineError ())
@@ -38,7 +41,7 @@ addMug :: MonadIO m => Machine -> m (Either MachineError ())
 
 ### Take Mug
 
-Similarly, we may remove a mug with the function:
+Similarly, we may remove a mug with the `takeMug` function:
 
 ```haskell
 takeMug :: MonadIO m => Machine -> m (Either MachineError Mug)
@@ -46,8 +49,9 @@ takeMug :: MonadIO m => Machine -> m (Either MachineError Mug)
 
 ### Collapse the `DrinkType` commands to one
 
-We're able to express the individual `Command`s for setting the different types
-of drink in a more condensed manner. Collapse the following three `Command`s:
+The drink commands we set up in the previous level involve a lot of
+boilerplate. We are able to use generators to express the three options for
+setting drink types as one `Command`. Collapse the following three `Command`s:
 
 * `cSetDrinkHotChocolate`
 * `cSetDrinkCoffee`

--- a/level03/CoffeeMachineTests.hs
+++ b/level03/CoffeeMachineTests.hs
@@ -4,20 +4,41 @@
 module CoffeeMachineTests (stateMachineTests) where
 
 import qualified CoffeeMachine as C
-import           Control.Lens (view)
+import           Control.Lens (view, (^?))
 import           Control.Monad.IO.Class (MonadIO)
 import           Data.Function ((&))
 import           Data.Kind (Type)
+import           Data.Maybe (isJust)
 import           Hedgehog
 import qualified Hedgehog.Gen as Gen
 import qualified Hedgehog.Range as Range
 import           Test.Tasty (TestTree)
 import           Test.Tasty.Hedgehog (testProperty)
 
-data DrinkType = Coffee | HotChocolate | Tea deriving (Bounded, Enum, Show)
-newtype Model (v :: Type -> Type) = Model DrinkType
+data DrinkType = Coffee | HotChocolate | Tea deriving (Bounded, Enum, Show, Eq)
+data DrinkAdditive = Milk | Sugar deriving (Bounded, Enum, Show)
+
+data Model (v :: Type -> Type) = Model
+  { _modelDrinkType :: DrinkType
+  , _modelHasMug    :: Bool
+  , _modelMilk      :: Int
+  , _modelSugar     :: Int
+  }
 
 newtype SetDrinkType (v :: Type -> Type) = SetDrinkType DrinkType deriving Show
+newtype AddMilkSugar (v :: Type -> Type) = AddMilkSugar DrinkAdditive deriving Show
+
+data AddMug (v :: Type -> Type) = AddMug deriving Show
+data TakeMug (v :: Type -> Type) = TakeMug deriving Show
+
+instance HTraversable AddMug where
+  htraverse _ _ = pure AddMug
+
+instance HTraversable TakeMug where
+  htraverse _ _ = pure TakeMug
+
+instance HTraversable AddMilkSugar where
+  htraverse _ (AddMilkSugar d) = pure $ AddMilkSugar d
 
 instance HTraversable SetDrinkType where
   htraverse _ (SetDrinkType d) = pure $ SetDrinkType d
@@ -27,32 +48,113 @@ cSetDrinkType
   => C.Machine
   -> Command g m Model
 cSetDrinkType mach = Command gen exec
-  [ Update $ \_ (SetDrinkType d) _ -> Model d
-  , Ensure $ \_ (Model d) _ drink -> case (d, drink) of
-      (Coffee, C.Coffee{}) -> success
+  [ Update $ \m (SetDrinkType d) _ -> m {
+      _modelDrinkType = d,
+      _modelMilk      = 0,
+      _modelSugar     = 0
+      }
+
+  , Ensure $ \_ newM _ drink -> case (_modelDrinkType newM, drink) of
+      (Coffee, C.Coffee{})           -> success
       (HotChocolate, C.HotChocolate) -> success
-      (Tea, C.Tea{}) -> success
-      _ -> failure
+      (Tea, C.Tea{})                 -> success
+      _                              -> failure
   ]
   where
     gen :: Model Symbolic -> Maybe (g (SetDrinkType Symbolic))
-    gen _ = Just $ SetDrinkType <$> Gen.enumBounded
+    gen _ = pure $ SetDrinkType <$> Gen.enumBounded
 
     exec :: SetDrinkType Concrete -> m C.Drink
     exec (SetDrinkType d) = evalIO $ do
       mach & case d of
-        Coffee -> C.coffee
+        Coffee       -> C.coffee
         HotChocolate -> C.hotChocolate
-        Tea -> C.tea
+        Tea          -> C.tea
+      view C.drinkSetting <$> C.peek mach
+
+
+cTakeMug
+  :: forall g m. (MonadGen g, MonadTest m, MonadIO m)
+  => C.Machine
+  -> Command g m Model
+cTakeMug mach = Command gen exec
+  [ Require $ \(Model _ hasMug _ _) _ -> hasMug
+  , Update $ \m _ _ -> m { _modelHasMug = False }
+  ]
+  where
+    gen :: MonadGen g => Model Symbolic -> Maybe (g (TakeMug Symbolic))
+    gen m | _modelHasMug m = (pure . pure) TakeMug
+          | otherwise = Nothing
+
+    exec :: TakeMug Concrete -> m C.Mug
+    exec _ = evalIO (C.takeMug mach) >>= evalEither
+
+cAddMug
+  :: forall g m. (MonadGen g, MonadTest m, MonadIO m)
+  => C.Machine
+  -> Command g m Model
+cAddMug mach = Command gen exec
+  [ Require $ \m _ -> not $ _modelHasMug m
+  , Update $ \m _ _ -> m { _modelHasMug = True }
+  , Ensure $ \_ _ _ -> assert . isJust
+  ]
+  where
+    gen :: MonadGen g => Model Symbolic -> Maybe (g (AddMug Symbolic))
+    gen m | not $ _modelHasMug m = (pure . pure) AddMug
+          | otherwise  = Nothing
+
+    exec :: AddMug Concrete -> m (Maybe C.Mug)
+    exec _ = do
+      evalIO (C.addMug mach) >>= evalEither
+      evalIO $ view C.mug <$> C.peek mach
+
+milkOrSugar :: DrinkAdditive -> a -> a -> a
+milkOrSugar Milk m  _ = m
+milkOrSugar Sugar _ s = s
+
+cAddMilkSugar
+  :: forall g m. (MonadGen g, MonadTest m, MonadIO m)
+  => C.Machine
+  -> Command g m Model
+cAddMilkSugar mach = Command gen exec
+  [ Require $ \m _ -> HotChocolate /= _modelDrinkType m
+
+  , Update $ \m (AddMilkSugar additive) _ -> case additive of
+      Milk -> m { _modelMilk = _modelMilk m + 1 }
+      Sugar -> m { _modelSugar = _modelSugar m + 1}
+
+  , Ensure $ \oldM newM (AddMilkSugar additive) mug' ->
+      let (additiveFn, sl) = milkOrSugar additive (_modelMilk, C.milk) (_modelSugar, C.sugar)
+
+          drinkAdditiveQty = case _modelDrinkType newM of
+            Coffee -> mug' ^? C._Coffee . sl
+            Tea    -> mug' ^? C._Tea . sl
+            _      -> Nothing
+
+      in do
+        (additiveFn newM) - (additiveFn oldM) === 1
+        Just (additiveFn newM) === drinkAdditiveQty
+  ]
+  where
+    gen :: MonadGen g => Model Symbolic -> Maybe (g (AddMilkSugar Symbolic))
+    gen m | HotChocolate /= _modelDrinkType m = pure (AddMilkSugar <$> Gen.enumBounded)
+          | otherwise = Nothing
+
+    exec :: (MonadTest m, MonadIO m) => AddMilkSugar Concrete -> m C.Drink
+    exec (AddMilkSugar additive) = evalIO $ do
+      milkOrSugar additive C.addMilk C.addSugar mach
       view C.drinkSetting <$> C.peek mach
 
 stateMachineTests :: TestTree
 stateMachineTests = testProperty "State Machine Tests" . property $ do
   mach <- C.newMachine
 
-  let initialModel = Model HotChocolate
+  let initialModel = Model HotChocolate False 0 0
       commands = ($ mach) <$>
         [ cSetDrinkType
+        , cAddMug
+        , cTakeMug
+        , cAddMilkSugar
         ]
 
   actions <- forAll $ Gen.sequential (Range.linear 1 100) initialModel commands

--- a/level03/README.md
+++ b/level03/README.md
@@ -1,2 +1,32 @@
-# Level03 - More Commands
+# Level03 - More Commands!
 
+In this level we're going to practice what we've learned so far by expanding our
+model a bit and implementing commands to test the following features of our
+machine:
+
+### Inserting Coins
+
+We can insert coins into the machine using the following function:
+
+```haskell
+insertCoins :: MonadIO m => Int -> Machine -> m ()
+```
+
+### Refunding Coins
+
+We can have our machine refund all the money inserted thus far with this
+function:
+
+```haskell
+refund :: MonadIO m => Machine -> m Int
+```
+
+### Adding Milk or Sugar
+
+We can add either milk or sugar with the following functions:
+
+```haskell
+addMilk :: MonadIO m => Machine -> m ()
+--
+addSugar :: MonadIO m => Machine -> m ()
+```

--- a/level03/README.md
+++ b/level03/README.md
@@ -1,0 +1,2 @@
+# Level03 - More Commands
+

--- a/level03/README.md
+++ b/level03/README.md
@@ -30,3 +30,6 @@ addMilk :: MonadIO m => Machine -> m ()
 --
 addSugar :: MonadIO m => Machine -> m ()
 ```
+
+You may implement this as one or two commands. As these functions have a lot in
+common, we recommend implementing this as a single `Command`.

--- a/level04/CoffeeMachineTests.hs
+++ b/level04/CoffeeMachineTests.hs
@@ -44,6 +44,16 @@ instance HTraversable AddMilkSugar where
 instance HTraversable SetDrinkType where
   htraverse _ (SetDrinkType d) = pure $ SetDrinkType d
 
+data RefundCoins (v :: Type -> Type) = RefundCoins deriving Show
+
+instance HTraversable RefundCoins where
+  htraverse _ _ = pure RefundCoins
+
+newtype InsertCoins (v :: Type -> Type) = InsertCoins Int deriving Show
+
+instance HTraversable InsertCoins where
+  htraverse _ (InsertCoins n) = pure (InsertCoins n)
+
 cSetDrinkType
   :: forall g m. (MonadGen g, MonadTest m, MonadIO m)
   => C.Machine

--- a/level04/CoffeeMachineTests.hs
+++ b/level04/CoffeeMachineTests.hs
@@ -26,17 +26,24 @@ data Model (v :: Type -> Type) = Model
   , _modelHasMug    :: Bool
   , _modelMilk      :: Int
   , _modelSugar     :: Int
+  , _modelCoins     :: Int
   }
 $(makeLenses ''Model)
 
-data AddMug (v :: Type -> Type) = AddMug deriving Show
-instance HTraversable AddMug where htraverse _ _ = pure AddMug
+newtype SetDrinkType (v :: Type -> Type) = SetDrinkType DrinkType deriving Show
 
+data AddMug (v :: Type -> Type)  = AddMug deriving Show
 data TakeMug (v :: Type -> Type) = TakeMug deriving Show
-instance HTraversable TakeMug where htraverse _ _ = pure TakeMug
 
 newtype AddMilkSugar (v :: Type -> Type) = AddMilkSugar DrinkAdditive deriving Show
-newtype SetDrinkType (v :: Type -> Type) = SetDrinkType DrinkType deriving Show
+newtype InsertCoins (v :: Type -> Type)  = InsertCoins Int deriving Show
+data RefundCoins (v :: Type -> Type)     = RefundCoins deriving Show
+
+instance HTraversable AddMug where
+  htraverse _ _ = pure AddMug
+
+instance HTraversable TakeMug where
+  htraverse _ _ = pure TakeMug
 
 instance HTraversable AddMilkSugar where
   htraverse _ (AddMilkSugar d) = pure $ AddMilkSugar d
@@ -44,12 +51,8 @@ instance HTraversable AddMilkSugar where
 instance HTraversable SetDrinkType where
   htraverse _ (SetDrinkType d) = pure $ SetDrinkType d
 
-data RefundCoins (v :: Type -> Type) = RefundCoins deriving Show
-
 instance HTraversable RefundCoins where
   htraverse _ _ = pure RefundCoins
-
-newtype InsertCoins (v :: Type -> Type) = InsertCoins Int deriving Show
 
 instance HTraversable InsertCoins where
   htraverse _ (InsertCoins n) = pure (InsertCoins n)
@@ -199,11 +202,50 @@ cAddMugSad mach = Command genAddMug exec
     exec :: AddMug Concrete -> m (Either C.MachineError ())
     exec _ = evalIO $ C.addMug mach
 
+cInsertCoins
+  :: forall g m. (MonadGen g, MonadTest m, MonadIO m)
+  => C.Machine
+  -> Command g m Model
+cInsertCoins mach = Command gen exec
+  [ Update $ \m (InsertCoins coins) _ -> m & modelCoins +~ coins
+
+  , Ensure $ \oldM newM (InsertCoins coins) currentCoins -> do
+      newM ^. modelCoins         === currentCoins
+      oldM ^. modelCoins + coins === currentCoins
+      newM ^. modelCoins - coins === oldM ^. modelCoins
+  ]
+  where
+    gen :: Model Symbolic -> Maybe (g (InsertCoins Symbolic))
+    gen _ = Just $ InsertCoins <$> Gen.int (Range.linear 0 100)
+
+    exec :: InsertCoins Concrete -> m Int
+    exec (InsertCoins coins) = evalIO $ do
+      C.insertCoins coins mach
+      view C.coins <$> C.peek mach
+
+cRefundCoins
+  :: forall g m. (MonadGen g, MonadTest m, MonadIO m)
+  => C.Machine
+  -> Command g m Model
+cRefundCoins mach = Command gen exec
+  [ Update $ \m _ _ -> m & modelCoins .~ 0
+
+  , Ensure $ \oldM newM _ refundCoins -> do
+      oldM ^. modelCoins - refundCoins === 0
+      newM ^. modelCoins + refundCoins === oldM ^. modelCoins
+  ]
+  where
+    gen :: Model Symbolic -> Maybe (g (RefundCoins Symbolic))
+    gen _ = Just $ pure RefundCoins
+
+    exec :: RefundCoins Concrete -> m Int
+    exec _ = evalIO (C.refund mach)
+
 stateMachineTests :: TestTree
 stateMachineTests = testProperty "State Machine Tests" . property $ do
   mach <- evalIO C.newMachine
 
-  let initialModel = Model HotChocolate False 0 0
+  let initialModel = Model HotChocolate False 0 0 0
       commands = ($ mach) <$>
         [ cSetDrinkType
         , cAddMugHappy
@@ -212,6 +254,8 @@ stateMachineTests = testProperty "State Machine Tests" . property $ do
         , cTakeMugSad
         , cAddMilkSugarHappy
         , cAddMilkSugarSad
+        , cInsertCoins
+        , cRefundCoins
         ]
 
   actions <- forAll $ Gen.sequential (Range.linear 1 100) initialModel commands

--- a/level04/README.md
+++ b/level04/README.md
@@ -7,3 +7,11 @@ execute a command when the 'ideal' requirements have not been satisfied.
 
 In this level you will write commands to ensure both the positive and negative
 paths are tested.
+
+Some negative operations to test:
+
+* Adding milk or sugar to a hot chocolate
+* Taking a mug that isn't there
+* Adding a mug when one is there
+
+Can you think of any others?

--- a/level04/README.md
+++ b/level04/README.md
@@ -1,40 +1,9 @@
 # Level 04 - Positive & Negative Testing
 
-In a previous level you implemented commands with pre-conditions to ensure
-they are only run when it is appropriate. However this only tests the 'positive'
-path within the application. To be thorough we need to add commands that may be
-interleaved and check what happens if we execute a command and our desired
-requirements have not been satisfied. In this level you will write commands to
-ensure both the positive and negative paths are tested.
+In a previous level you implemented commands with pre-conditions to ensure they
+are only run when it is appropriate. However this only tests the 'positive' path
+within the application. To be thorough we need to check what happens if we
+execute a command when the 'ideal' requirements have not been satisfied.
 
-<!-- We're starting to build up an nice list of commands. So far they have all -->
-<!-- separate parts of our model. There are no dependencies so Hedgehog is free to -->
-<!-- generate and shrink as it chooses, any sequence of commands is as valid as any -->
-<!-- other. -->
-
-<!-- But we need a way to ensure that our commands will only run when it makes sense -->
-<!-- to do so. Otherwise we will have commands that execute and fail our tests when -->
-<!-- those commands should never have been included to begin with. -->
-
-<!-- We will use the `takeMug` function as an example. If we were to include a -->
-<!-- `Command` for this function without an appropriate `Require`, our tests would -->
-<!-- pass randomly, only when this command happened to be included in the right -->
-<!-- order. -->
-
-<!-- However if we expanded our model to track whether we had added a mug. Then we -->
-<!-- could prevent the `takeMug` command from being a valid command unless our -->
-<!-- criteria had been satisified. -->
-
-<!-- The type of drink we have selected is another example of this. If we wanted to -->
-<!-- check that the buttons to add milk or sugar were working correctly, then we need -->
-<!-- to make sure we have the correct type of drink selected. -->
-
-<!-- The goal for this level is to implement the following commands: -->
-
-<!-- * Add Milk/Sugar -->
-<!-- * Add Mug -->
-<!-- * Take Mug -->
-
-<!-- Be sure to check both the positive (happy) and negative (sad) paths! You will -->
-<!-- have to ensure that your `Command`s have the correct pre-conditions and -->
-<!-- `Require` checks. -->
+In this level you will write commands to ensure both the positive and negative
+paths are tested.

--- a/level04/README.md
+++ b/level04/README.md
@@ -1,33 +1,40 @@
-# Level 04 - Pre-conditions
+# Level 04 - Positive & Negative Testing
 
-We're starting to build up an nice list of commands. So far they have all
-separate parts of our model. There are no dependencies so Hedgehog is free to
-generate and shrink as it chooses, any sequence of commands is as valid as any
-other.
+In a previous level you implemented commands with pre-conditions to ensure
+they are only run when it is appropriate. However this only tests the 'positive'
+path within the application. To be thorough we need to add commands that may be
+interleaved and check what happens if we execute a command and our desired
+requirements have not been satisfied. In this level you will write commands to
+ensure both the positive and negative paths are tested.
 
-But we need a way to ensure that our commands will only run when it makes sense
-to do so. Otherwise we will have commands that execute and fail our tests when
-those commands should never have been included to begin with.
+<!-- We're starting to build up an nice list of commands. So far they have all -->
+<!-- separate parts of our model. There are no dependencies so Hedgehog is free to -->
+<!-- generate and shrink as it chooses, any sequence of commands is as valid as any -->
+<!-- other. -->
 
-We will use the `takeMug` function as an example. If we were to include a
-`Command` for this function without an appropriate `Require`, our tests would
-pass randomly, only when this command happened to be included in the right
-order.
+<!-- But we need a way to ensure that our commands will only run when it makes sense -->
+<!-- to do so. Otherwise we will have commands that execute and fail our tests when -->
+<!-- those commands should never have been included to begin with. -->
 
-However if we expanded our model to track whether we had added a mug. Then we
-could prevent the `takeMug` command from being a valid command unless our
-criteria had been satisified.
+<!-- We will use the `takeMug` function as an example. If we were to include a -->
+<!-- `Command` for this function without an appropriate `Require`, our tests would -->
+<!-- pass randomly, only when this command happened to be included in the right -->
+<!-- order. -->
 
-The type of drink we have selected is another example of this. If we wanted to
-check that the buttons to add milk or sugar were working correctly, then we need
-to make sure we have the correct type of drink selected.
+<!-- However if we expanded our model to track whether we had added a mug. Then we -->
+<!-- could prevent the `takeMug` command from being a valid command unless our -->
+<!-- criteria had been satisified. -->
 
-The goal for this level is to implement the following commands:
+<!-- The type of drink we have selected is another example of this. If we wanted to -->
+<!-- check that the buttons to add milk or sugar were working correctly, then we need -->
+<!-- to make sure we have the correct type of drink selected. -->
 
-* Add Milk/Sugar
-* Add Mug
-* Take Mug
+<!-- The goal for this level is to implement the following commands: -->
 
-Be sure to check both the positive (happy) and negative (sad) paths! You will
-have to ensure that your `Command`s have the correct pre-conditions and
-`Require` checks.
+<!-- * Add Milk/Sugar -->
+<!-- * Add Mug -->
+<!-- * Take Mug -->
+
+<!-- Be sure to check both the positive (happy) and negative (sad) paths! You will -->
+<!-- have to ensure that your `Command`s have the correct pre-conditions and -->
+<!-- `Require` checks. -->

--- a/level04/README.md
+++ b/level04/README.md
@@ -1,13 +1,15 @@
 # Level 04 - Positive & Negative Testing
 
-In a previous level you implemented commands with pre-conditions to ensure they
-are only run when they are guaranteed to succeed. However this only tests the
-'positive' path within the application. To be thorough we need to check what
-happens if we execute a command when the 'ideal' requirements have not been
-satisfied.
+In a previous level you implemented commands with pre-conditions to
+ensure they are only run when they are guaranteed to succeed. However
+this only tests the 'positive' path within the application. To be
+thorough we need commands that do the 'wrong' thing. These 'negative'
+commands should use `Ensure` callbacks to verify that errors are
+correctly raised, and that the state doesn't change in unexpected
+ways.
 
-In this level you will write commands to ensure both the positive and negative
-paths are tested.
+In this level you will write negative commands to complement your
+existing positive ones.
 
 Some negative operations to test:
 

--- a/level04/README.md
+++ b/level04/README.md
@@ -1,9 +1,10 @@
 # Level 04 - Positive & Negative Testing
 
 In a previous level you implemented commands with pre-conditions to ensure they
-are only run when it is appropriate. However this only tests the 'positive' path
-within the application. To be thorough we need to check what happens if we
-execute a command when the 'ideal' requirements have not been satisfied.
+are only run when they are guaranteed to succeed. However this only tests the
+'positive' path within the application. To be thorough we need to check what
+happens if we execute a command when the 'ideal' requirements have not been
+satisfied.
 
 In this level you will write commands to ensure both the positive and negative
 paths are tested.

--- a/level05/CoffeeMachineTests.hs
+++ b/level05/CoffeeMachineTests.hs
@@ -292,7 +292,7 @@ cCheckCredit _ = Command gen (\_ -> pure ())
          & modelSufficientCredit .~ case (m ^. modelCoins) `compare` cost of
                                       GT -> TooMuch
                                       EQ -> Enough
-                                      _  -> TooLittle
+                                      LT -> TooLittle
   ]
   where
     gen :: Model Symbolic -> Maybe (g (CheckCredit Symbolic))

--- a/level05/CoffeeMachineTests.hs
+++ b/level05/CoffeeMachineTests.hs
@@ -289,8 +289,10 @@ cCheckCredit _ = Command gen (\_ -> pure ())
 
       in m
          & modelDrinkCost .~ cost
-         & modelSufficientCredit .~ if m ^. modelCoins > cost then TooMuch
-                                    else if m ^. modelCoins == cost then Enough else TooLittle
+         & modelSufficientCredit .~ case (m ^. modelCoins) `compare` cost of
+                                      GT -> TooMuch
+                                      EQ -> Enough
+                                      _  -> TooLittle
   ]
   where
     gen :: Model Symbolic -> Maybe (g (CheckCredit Symbolic))

--- a/level05/CoffeeMachineTests.hs
+++ b/level05/CoffeeMachineTests.hs
@@ -19,15 +19,15 @@ import qualified Hedgehog.Range         as Range
 import           Test.Tasty             (TestTree)
 import           Test.Tasty.Hedgehog    (testProperty)
 
-data DrinkType 
-  = Coffee 
-  | HotChocolate 
-  | Tea 
+data DrinkType
+  = Coffee
+  | HotChocolate
+  | Tea
   deriving (Bounded, Enum, Show, Eq)
 
-data DrinkAdditive 
-  = Milk 
-  | Sugar 
+data DrinkAdditive
+  = Milk
+  | Sugar
   deriving (Bounded, Enum, Show)
 
 data MugStatus

--- a/level05/README.md
+++ b/level05/README.md
@@ -25,5 +25,18 @@ other `Command`s are able to check more easily.
 
 In this level we're going to check the following steps:
 
-* Current Credit
-* Dispensing a drink
+### Current Credit
+
+The function for checking the cost of the current drink cofiguration is:
+
+```haskell
+currentDrinkCost :: MonadIO m => Machine -> m Int
+```
+
+### Dispensing a drink
+
+The function for dispensing a drink is:
+
+```haskell
+dispense :: MonadIO m => Machine -> m (Either MachineError ())
+```

--- a/level05/README.md
+++ b/level05/README.md
@@ -21,11 +21,11 @@ This style of `Command` acts as a 'transition' within the state machine that
 we're building. These 'transition' `Command`s serve to restrict the generated
 tests to valid subsets of `Command`s.
 
-Transition `Commands** collect complicated logic for transitions into a single
-location and set values on the model that other `Command`s are able to check
-more easily.
+Transition `Commands` collect the logic for transitions into a single location
+and set values on the model that other `Command`s are able to check more
+easily.
 
-The goal for this level is to write a `Command** that dispenses a drink and
+The goal for this level is to write a `Command` that dispenses a drink and
 checks that this drink matches our expectations, based on our current model of
 what the drink should be.
 

--- a/level05/README.md
+++ b/level05/README.md
@@ -5,43 +5,40 @@ commands, we're building another state machine! One that could almost be a
 replica of the thing we're trying to test. This is a problem: our goal is to
 prove that the thing we're testing operates correctly, not duplicate it.
 
-So, how do we create _just enough_ of a model so we're able to write
-useful tests, without creating a crummy duplicate of the thing we're
-testing? This is where state machine testing becomes an art.
+So, how do we create _just enough_ of a model so we're able to write useful
+tests, without creating a crummy duplicate of the thing we're testing? This is
+where state machine testing becomes an art.
 
-The goal: how do we _minimise_ the model so we can still write
-sensible `Command`s? This often depends on the thing that you're
-testing, but there are some general techniques.
+The goal: how do we _minimise_ the model so we can still write sensible
+`Command`s? This often depends on the thing that you're testing, but there are
+some general techniques.
 
-One technique is to define `Command`(s) that do nothing but inspect
-the current model and update specific values that will be used by
-`Require` or `Ensure` callbacks in subsequent `Command`s.
+One technique is to define `Command`(s) that do nothing but inspect the
+current model and update specific values that will be used by `Require` or
+`Ensure` callbacks in subsequent `Command`s.
 
-This style of `Command` acts as a 'transition' within the state
-machine that we're building. These 'transition' `Command`s serve to
-restrict the generated tests to valid subsets of `Command`s.
+This style of `Command` acts as a 'transition' within the state machine that
+we're building. These 'transition' `Command`s serve to restrict the generated
+tests to valid subsets of `Command`s.
 
-Transition `Commands` collect complicated logic for transitions into a
-single location and set values on the model that other `Command`s are
-able to check more easily.
+Transition `Commands** collect complicated logic for transitions into a single
+location and set values on the model that other `Command`s are able to check
+more easily.
 
-The goal for this level is to write a `Command` that dispenses a drink
-and checks that this drink matches our expectations, based on our
-current model of what the drink should be.
+The goal for this level is to write a `Command** that dispenses a drink and
+checks that this drink matches our expectations, based on our current model of
+what the drink should be.
 
-To be able to write a `Command` that dispenses our drink we're going
-to need to know:
+**NB:** We have deliberately provided limited guidance on how to complete this
+exercise. Not because we're mean, but because we consider this to be a vital
+skill for effectively applying state machine testing to large and complex
+systems.
 
-- how much our drink should cost
-- whether we have a mug in place
-- if we have inserted enough coins
-
-A couple of functions that will be used in this level:
+Some functions that will be useful:
 
 ### Current Credit
 
-The function for checking the cost of the current drink configuration
-is:
+The function for checking the cost of the current drink configuration is:
 
 ```haskell
 currentDrinkCost :: MonadIO m => Machine -> m Int

--- a/level05/README.md
+++ b/level05/README.md
@@ -25,6 +25,5 @@ other `Command`s are able to check more easily.
 
 In this level we're going to check the following steps:
 
-* Inserting coins
-* Refunding coins
+* Current Credit
 * Dispensing a drink

--- a/level05/README.md
+++ b/level05/README.md
@@ -2,33 +2,35 @@
 
 You may have noticed that in the process of building the model and various
 commands, we're building another state machine! One that could almost be a
-replica of the thing we're trying to test. This is a problem as our goal is to
+replica of the thing we're trying to test. This is a problem: our goal is to
 prove that the thing we're testing operates correctly, not duplicate it.
 
-So, how to create _just enough_ of a model so we're able to write useful tests,
-without creating a crummy duplicate of the thing we're testing? This is where
-state machine testing becomes a bit of an art.
+So, how do we create _just enough_ of a model so we're able to write
+useful tests, without creating a crummy duplicate of the thing we're
+testing? This is where state machine testing becomes an art.
 
-The goal can be described as, how do we _minimise_ the model so we can still
-write sensible `Command`s? This often depends on the thing that you're testing,
-but there are some general techniques we can apply.
+The goal: how do we _minimise_ the model so we can still write
+sensible `Command`s? This often depends on the thing that you're
+testing, but there are some general techniques.
 
-One such technique is to implement `Command`(s) that do nothing but inspect
-the current model and update specific values that will be used by subsequent
-`Command`s in `Require` or `Ensure` callbacks.
+One technique is to define `Command`(s) that do nothing but inspect
+the current model and update specific values that will be used by
+`Require` or `Ensure` callbacks in subsequent `Command`s.
 
-This style of `Command` would act as a 'transition' within the state machine
-that we're building to manage our tests. These 'transition' style `Command`s
-serve to guide the tests to valid subsets of `Command`s. 
+This style of `Command` acts as a 'transition' within the state
+machine that we're building. These 'transition' `Command`s serve to
+restrict the generated tests to valid subsets of `Command`s.
 
-You collect complicated logic for transitions in a single location and set
-values on the model that other `Command`s are able to check more easily.
+Transition `Commands` collect complicated logic for transitions into a
+single location and set values on the model that other `Command`s are
+able to check more easily.
 
-The goal for this level is to be able to write a `Command` that dispenses a
-drink and checks that this drink matches our expectations, based on our current
-model of what the drink should be.
+The goal for this level is to write a `Command` that dispenses a drink
+and checks that this drink matches our expectations, based on our
+current model of what the drink should be.
 
-To be able to write a `Command` that dispenses our drink we're going to need to know:
+To be able to write a `Command` that dispenses our drink we're going
+to need to know:
 
 - how much our drink should cost
 - whether we have a mug in place
@@ -38,7 +40,8 @@ A couple of functions that will be used in this level:
 
 ### Current Credit
 
-The function for checking the cost of the current drink configuration is:
+The function for checking the cost of the current drink configuration
+is:
 
 ```haskell
 currentDrinkCost :: MonadIO m => Machine -> m Int

--- a/level05/README.md
+++ b/level05/README.md
@@ -3,17 +3,17 @@
 You may have noticed that in the process of building the model and various
 commands, we're building another state machine! One that could almost be a
 replica of the thing we're trying to test. This is a problem as our goal is to
-prove that the thing we're testing is correct, not duplicate it.
+prove that the thing we're testing operates correctly, not duplicate it.
 
 So, how to create _just enough_ of a model so we're able to write useful tests,
 without creating a crummy duplicate of the thing we're testing? This is where
 state machine testing becomes a bit of an art.
 
-The primary question being, how do you _minimise_ your model so you can still
-write sensible `Command`s? This often depends on the thing that you're testing.
-But there are some general techniques we can apply.
+The goal can be described as, how do we _minimise_ the model so we can still
+write sensible `Command`s? This often depends on the thing that you're testing,
+but there are some general techniques we can apply.
 
-One general technique is to implement `Command`(s) that do nothing but inspect
+One such technique is to implement `Command`(s) that do nothing but inspect
 the current model and update specific values that will be used by subsequent
 `Command`s in `Require` or `Ensure` callbacks.
 
@@ -21,13 +21,8 @@ This style of `Command` would act as a 'transition' within the state machine
 that we're building to manage our tests. These 'transition' style `Command`s
 serve to guide the tests to valid subsets of `Command`s. 
 
-You collect complicated logic for transitions in a single location and set a
-single value on the model that other `Command`s are able to check more easily.
-
-The types aid us in achieving this as the inputs to `Require` or `commandGen`
-are tagged as `Symbolic`. Preventing us from directly using output from the
-thing we're testing in either the `Require` or `commandGen` sections of our
-`Command`.
+You collect complicated logic for transitions in a single location and set
+values on the model that other `Command`s are able to check more easily.
 
 The goal for this level is to be able to write a `Command` that dispenses a
 drink and checks that this drink matches our expectations, based on our current
@@ -39,9 +34,11 @@ To be able to write a `Command` that dispenses our drink we're going to need to 
 - whether we have a mug in place
 - if we have inserted enough coins
 
+A couple of functions that will be used in this level:
+
 ### Current Credit
 
-The function for checking the cost of the current drink cofiguration is:
+The function for checking the cost of the current drink configuration is:
 
 ```haskell
 currentDrinkCost :: MonadIO m => Machine -> m Int

--- a/level05/README.md
+++ b/level05/README.md
@@ -1,29 +1,43 @@
 # Level 05 - Divergence and Phases
 
-You'll notice that in the process of building tests for our state machine,
-we're building another state machine!
+You may have noticed that in the process of building the model and various
+commands, we're building another state machine! One that could almost be a
+replica of the thing we're trying to test. This is a problem as our goal is to
+prove that the thing we're testing is correct, not duplicate it.
 
-However, we must only create _'just enough'_ of a model so that Hedgehog has
-the information it needs to generate sensible `Command` sequences. Whilst we
-avoid creating a duplicate of the thing we're trying to test, or needlessly
-exposing its inner workings.
+So, how to create _just enough_ of a model so we're able to write useful tests,
+without creating a crummy duplicate of the thing we're testing? This is where
+state machine testing becomes a bit of an art.
+
+The primary question being, how do you _minimise_ your model so you can still
+write sensible `Command`s? This often depends on the thing that you're testing.
+But there are some general techniques we can apply.
+
+One general technique is to implement `Command`(s) that do nothing but inspect
+the current model and update specific values that will be used by subsequent
+`Command`s in `Require` or `Ensure` callbacks.
+
+This style of `Command` would act as a 'transition' within the state machine
+that we're building to manage our tests. These 'transition' style `Command`s
+serve to guide the tests to valid subsets of `Command`s. 
+
+You collect complicated logic for transitions in a single location and set a
+single value on the model that other `Command`s are able to check more easily.
 
 The types aid us in achieving this as the inputs to `Require` or `commandGen`
-are tagged as `Symbolic`. This prevent us from directly using output from the
+are tagged as `Symbolic`. Preventing us from directly using output from the
 thing we're testing in either the `Require` or `commandGen` sections of our
 `Command`.
 
-This is where state machine testing becomes a bit of an art. How will you
-track the required knowledge about the thing you're testing so that you can
-write sensible commands? Sometimes this may require implementing a `Command`
-that examines and updates the model.
+The goal for this level is to be able to write a `Command` that dispenses a
+drink and checks that this drink matches our expectations, based on our current
+model of what the drink should be.
 
-This style of `Command` would act as a 'transition'. Guiding the tests to
-valid subsets of `Command`s. This allows you collect complicated logic for
-transitions in a single location and set a single value on the model that
-other `Command`s are able to check more easily.
+To be able to write a `Command` that dispenses our drink we're going to need to know:
 
-In this level we're going to check the following steps:
+- how much our drink should cost
+- whether we have a mug in place
+- if we have inserted enough coins
 
 ### Current Credit
 


### PR DESCRIPTION
Shuffling commands around based on the following concept for new level structure:

- [x] Lens Cheatsheet:
  - [x] View
  - [x] Set/Over
- [x] Prisms:
  - [x] preview
  - [x] review
- [x] Composition 

Level01 - "Introduction, setup etc":

- [x] Three separate commands (cSetDrinkCoffee, cSetDrinkHotChocolate, cSetDrinkTea)

Level02 - "Pre-conditions, commands with arguments":

- [x] (Commands with args) - Collapse set drink type commands to cSetDrinkType
- [x] (Preconditions) - cAddMug, cTakeMug
- [x] level readme

Level03 - "More commands!":

- [x] (Expansion of model / practice) - cInsertCoins, cRefundCoins
- [x] (args & preconditions practice) - cAddMilkSugar
- [x] level readme

Level04 - "Positive / Negative Testing":

- [x] Implement happy/sad versions of commands
- [x] discussions about why this matters
- [x] level readme

Level05 - "Phases and keeping your model sane":

- [x] discuss and implement cCheckCredit
- [x] implement cDispenseHappy
- [x] level readme

An extension to provide more exercises is to have an open ended assignment to implement a connected ordering system so the machine never runs out of coffee/additives etc. #showerthought