### PR TITLE
Remove evalIO calls

### DIFF
--- a/level01/CoffeeMachineTests.hs
+++ b/level01/CoffeeMachineTests.hs
@@ -39,7 +39,7 @@ cSetDrinkCoffee mach = Command gen exec
     gen _ = Just $ pure SetDrinkCoffee
 
     exec :: SetDrinkCoffee Concrete -> m C.Drink
-    exec _ = evalIO $ do
+    exec _ = do
       C.coffee mach
       view C.drinkSetting <$> C.peek mach
 
@@ -72,5 +72,5 @@ stateMachineTests = testProperty "State Machine Tests" . property $ do
         ]
 
   actions <- forAll $ Gen.sequential (Range.linear 1 100) initialModel commands
-  evalIO $ C.reset mach
+  C.reset mach
   executeSequential initialModel actions

--- a/level02/CoffeeMachineTests.hs
+++ b/level02/CoffeeMachineTests.hs
@@ -63,7 +63,7 @@ cSetDrinkCoffee mach = Command gen exec
     gen _ = Just $ pure SetDrinkCoffee
 
     exec :: SetDrinkCoffee Concrete -> m C.Drink
-    exec _ = evalIO $ do
+    exec _ = do
       C.coffee mach
       view C.drinkSetting <$> C.peek mach
 
@@ -82,7 +82,7 @@ cSetDrinkHotChocolate mach = Command gen exec
     gen _ = Just $ pure SetDrinkHotChocolate
 
     exec :: SetDrinkHotChocolate Concrete -> m C.Drink
-    exec _ = evalIO $ do
+    exec _ = do
       C.hotChocolate mach
       view C.drinkSetting <$> C.peek mach
 
@@ -101,7 +101,7 @@ cSetDrinkTea mach = Command gen exec
     gen _ = Just $ pure SetDrinkTea
 
     exec :: SetDrinkTea Concrete -> m C.Drink
-    exec _ = evalIO $ do
+    exec _ = do
       C.tea mach
       view C.drinkSetting <$> C.peek mach
 
@@ -154,5 +154,5 @@ stateMachineTests = testProperty "State Machine Tests" . property $ do
         ]
 
   actions <- forAll $ Gen.sequential (Range.linear 1 100) initialModel commands
-  evalIO $ C.reset mach
+  C.reset mach
   executeSequential initialModel actions

--- a/level03/CoffeeMachineTests.hs
+++ b/level03/CoffeeMachineTests.hs
@@ -69,7 +69,7 @@ cSetDrinkType mach = Command gen exec
     gen _ = pure $ SetDrinkType <$> Gen.enumBounded
 
     exec :: SetDrinkType Concrete -> m C.Drink
-    exec (SetDrinkType d) = evalIO $ do
+    exec (SetDrinkType d) = do
       mach & case d of
         Coffee       -> C.coffee
         HotChocolate -> C.hotChocolate
@@ -93,8 +93,8 @@ cTakeMug mach = Command gen exec
 
     exec :: TakeMug Concrete -> m (Maybe C.Mug)
     exec _ = do
-      _ <- evalIO (C.takeMug mach) >>= evalEither
-      evalIO $ view C.mug <$> C.peek mach
+      _ <- C.takeMug mach >>= evalEither
+      view C.mug <$> C.peek mach
 
 cAddMug
   :: forall g m. (MonadGen g, MonadTest m, MonadIO m)
@@ -112,8 +112,8 @@ cAddMug mach = Command gen exec
 
     exec :: AddMug Concrete -> m (Maybe C.Mug)
     exec _ = do
-      evalIO (C.addMug mach) >>= evalEither
-      evalIO $ view C.mug <$> C.peek mach
+      C.addMug mach >>= evalEither
+      view C.mug <$> C.peek mach
 
 
 stateMachineTests :: TestTree
@@ -131,5 +131,5 @@ stateMachineTests = testProperty "State Machine Tests" . property $ do
         ]
 
   actions <- forAll $ Gen.sequential (Range.linear 1 100) initialModel commands
-  evalIO $ C.reset mach
+  C.reset mach
   executeSequential initialModel actions


### PR DESCRIPTION
Turns out the coffee machine was using MonadIO, so all the evalIO was redundant.